### PR TITLE
Add the feature to create deliveries in a modal

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.btn {
+  @apply bg-blue-500 text-white font-bold py-2 px-4 rounded;
+}

--- a/src/components/CreateDeliveryModal.tsx
+++ b/src/components/CreateDeliveryModal.tsx
@@ -1,0 +1,87 @@
+import React, { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { addDelivery } from "../fake-db";
+
+const CreateDeliveryModal = (props: {
+  x: boolean;
+  setX: (x: boolean) => void;
+}) => {
+  const { x, setX } = props;
+  const queryClient = useQueryClient();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const { mutate } = useMutation({
+    mutationFn: (opts: {
+      name: string;
+      status: string;
+      deliveryDate: Date;
+    }) => addDelivery(opts.name, opts.status, opts.deliveryDate as any as string),
+    onMutate: () => {
+      setIsLoading(true);
+    },
+    onSuccess: async () => {
+      console.log("Invalidating query");
+      queryClient.invalidateQueries({ queryKey: ["deliveries"] });
+      setIsLoading(false);
+    },
+  });
+
+  const [name, setName] = React.useState("");
+  const [status, setStatus] = useState("");
+  const [deliveryDate, setDeliveryDate] = React.useState("");
+
+  return (
+    <div className="absolute bg-white top-10 left-10 bottom-10 right-10 shadow-xl border-2 border-black">
+      <h1 className="text-2xl my-2 flex flex-row">
+        <span className="flex-grow">Create delivery</span>
+        <button className="btn" onClick={() => setX(false)}>
+          X
+        </button>
+      </h1>
+      <div className="flex flex-col gap-2">
+        <p>
+          <label>Name</label>
+          <input
+            className="border-2 border-black"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </p>
+        <p>
+          <label>Status</label>
+          <input
+            className="border-2 border-black"
+            type="text"
+            value={status}
+            onChange={(e) => setStatus(e.target.value)}
+          />
+        </p>
+        <p>
+          <label>Delivery date</label>
+          <input
+            className="border-2 border-black"
+            type="date"
+            value={deliveryDate}
+            onChange={(e) => setDeliveryDate(e.target.value)}
+          />
+        </p>
+
+        <button
+          className="bg-red-500 text-white p-2"
+          onClick={() => {
+            mutate({
+              name: name,
+              status: status,
+              deliveryDate: (deliveryDate as unknown) as Date,
+            });
+          }}
+        >
+          {isLoading ? "Loading..." : "Create delivery"}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default CreateDeliveryModal;

--- a/src/components/ListDeliveries.tsx
+++ b/src/components/ListDeliveries.tsx
@@ -1,14 +1,23 @@
 import { useQuery } from "@tanstack/react-query";
 import { getDeliveries } from "../fake-db";
 import { useEffect, useState } from "react";
+import CreateDeliveryModal from "./CreateDeliveryModal";
 
 const ListDeliveries = () => {
   const [actualDeliveries, setDeliveries] = useState<any>([]);
+  const [showModal, setShowModal] = useState(false);
 
   const { data: deliveries } = useQuery({
     queryKey: ["deliveries"],
     queryFn: getDeliveries,
   });
+
+  useEffect(() => {
+    console.log("UseEffect");
+    if (deliveries) {
+      setDeliveries(deliveries);
+    }
+  }, [deliveries]);
 
   if (!deliveries) {
     return <div>Loading...</div>;
@@ -18,12 +27,18 @@ const ListDeliveries = () => {
     <div className="font-mono flex flex-col gap-4">
       <h1 className="text-center text-3xl">Deliveries</h1>
       <ul className="grid grid-cols-2 text-center">
-        {deliveries.map((delivery) => (
+        {actualDeliveries.map((delivery) => (
           <li key={delivery.name}>
             {delivery.name} - {delivery.status}
           </li>
         ))}
       </ul>
+      <div>
+        <button className="btn" onClick={() => setShowModal(true)}>
+          Add Delivery
+        </button>
+      </div>
+      {showModal && <CreateDeliveryModal x={showModal} setX={setShowModal} />}
     </div>
   );
 };


### PR DESCRIPTION
# Description
This PR adds functionality to create deliveries in the delivery list. Creating a delivery takes you into a modal, it takes a name/material, status and a delivery date. After creation the modal gets closed and the new deliveries are listed.

-----------

## Before 
A simple listing of the existing deliveries
![Screenshot from 2024-11-14 19-57-16](https://github.com/user-attachments/assets/2dfca4c3-2ea2-44e0-b12b-09b963078cce)


## After
There's a button to add a delivery(bring you to a modal)
![Screenshot from 2024-11-14 20-01-20](https://github.com/user-attachments/assets/bf191665-51a3-43f2-93b5-837a8ca1d953)


Fill in the required information and create your delivery
![Screenshot from 2024-11-14 20-20-30](https://github.com/user-attachments/assets/d97ad44c-8693-4657-ad9f-e0f10fbc4065)

Loading state
![Screenshot from 2024-11-14 20-20-47](https://github.com/user-attachments/assets/6afd30f1-627f-4478-a093-7164d2e13547)



All done, new delivery is added
![Screenshot from 2024-11-14 20-20-54](https://github.com/user-attachments/assets/a753a41e-08e3-48f6-9667-d8425944c17c)